### PR TITLE
feat: getDeck クエリおよび関連 VTL テンプレート追加

### DIFF
--- a/backend/internal/handler/bff/lambda-handler.go
+++ b/backend/internal/handler/bff/lambda-handler.go
@@ -26,7 +26,7 @@ type Response struct {
 }
 
 func HandleRequest(ctx context.Context, request Request) (interface{}, error) {
-	fmt.Println("request", request)
+	fmt.Printf("request: %+v, operation: %s\n", string(request.Data), request.Operation)
 	// Initialize AWS SDK
 	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {

--- a/backend/internal/repository/deck/dynamodb.go
+++ b/backend/internal/repository/deck/dynamodb.go
@@ -42,6 +42,7 @@ func (r *DynamoRepository) Create(ctx context.Context, deck *protobuf.Deck) erro
 
 // Get は指定された Deck を取得します。
 func (r *DynamoRepository) Get(ctx context.Context, id, owner string) (*protobuf.Deck, error) {
+	fmt.Printf("id: %s, owner: %s\n", id, owner)
 	result, err := r.client.GetItem(ctx, &dynamodb.GetItemInput{
 		TableName: aws.String(r.tableName),
 		Key: map[string]types.AttributeValue{
@@ -54,7 +55,7 @@ func (r *DynamoRepository) Get(ctx context.Context, id, owner string) (*protobuf
 	}
 
 	if result.Item == nil {
-		return nil, nil
+		return nil, errors.New("deck not found")
 	}
 
 	return &protobuf.Deck{

--- a/infra/appsync-vtl/Deck/Query/getDeck/req.vtl
+++ b/infra/appsync-vtl/Deck/Query/getDeck/req.vtl
@@ -1,0 +1,13 @@
+#set($userId = $ctx.identity.claims.sub)
+
+{
+  "version": "2018-05-29",
+  "operation": "Invoke",
+  "payload": {
+    "operation": "GetDeck",
+    "data": {
+      "deckId": $util.toJson($ctx.args.deckId),
+      "owner": $util.toJson($userId)
+    }
+  }
+}

--- a/infra/appsync-vtl/Deck/Query/getDeck/res.vtl
+++ b/infra/appsync-vtl/Deck/Query/getDeck/res.vtl
@@ -1,0 +1,5 @@
+#if($ctx.error)
+  $util.error($ctx.error.message, $ctx.error.type)
+#end
+
+$util.toJson($context.result.deck)

--- a/infra/lib/components/appsync.ts
+++ b/infra/lib/components/appsync.ts
@@ -88,5 +88,18 @@ export class AppsyncConstruct extends Construct {
         )
       ),
     });
+
+    // getDeckリゾルバを作成
+    this.api.createResolver("getDeck", {
+      typeName: "Query",
+      fieldName: "getDeck",
+      dataSource: lambdaDataSource,
+      requestMappingTemplate: appsync.MappingTemplate.fromFile(
+        path.join(__dirname, "../../appsync-vtl/Deck/Query/getDeck/req.vtl")
+      ),
+      responseMappingTemplate: appsync.MappingTemplate.fromFile(
+        path.join(__dirname, "../../appsync-vtl/Deck/Query/getDeck/res.vtl")
+      ),
+    });
   }
 }

--- a/infra/schema/schema.graphql
+++ b/infra/schema/schema.graphql
@@ -15,6 +15,7 @@ type Card {
 type Query {
   listCards(deckId: ID!): [Card!]!
   listDecks(owner: String!): [Deck!]!
+  getDeck(deckId: ID!): Deck!
 }
 
 type Mutation {


### PR DESCRIPTION
- GraphQL スキーマに getDeck クエリを追加し、ID で特定のデッキを取得可能に
- AppSync の getDeck リゾルバ用にリクエスト／レスポンスマッピングテンプレートを作成
- DynamoDB リポジトリのログ出力を強化し、トレース性を向上
- HandleRequest 関数を更新し、ログに操作名を含めるように
- Get メソッドで存在しないデッキへのアクセス時のエラーハンドリングを改善
close #7
